### PR TITLE
Use Multi-stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+zendesk-mock
+.idea/
+.git/
+README.md
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM scratch
+FROM golang:1.8.3-alpine AS golang-build
+RUN mkdir -p /go/src/github.com/AirHelp/zendesk-mock
+WORKDIR /go/src/github.com/AirHelp/zendesk-mock
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o zendesk-mock .
 
-ADD zendesk-mock /
+FROM scratch
+COPY --from=golang-build /go/src/github.com/AirHelp/zendesk-mock/zendesk-mock .
 CMD ["/zendesk-mock"]


### PR DESCRIPTION
Multi-stage builds are a new feature in Docker 17.05. More details here: https://docs.docker.com/engine/userguide/eng-image/multistage-build/

Please don't merge it until we'll upgrade docker on our CI servers.

Sample output:
```
$ docker build -t zendesk-mock:test .
Sending build context to Docker daemon    107kB
Step 1/8 : FROM golang:1.8.3-alpine AS golang-build
 ---> 0eb10ccd6a58
Step 2/8 : RUN mkdir -p /go/src/github.com/AirHelp/zendesk-mock
 ---> Running in 16d290b2b906
 ---> 3f3936f16ba1
Removing intermediate container 16d290b2b906
Step 3/8 : WORKDIR /go/src/github.com/AirHelp/zendesk-mock
 ---> bf98acda6e78
Removing intermediate container d12da6086cfc
Step 4/8 : COPY . .
 ---> f7ed89f9fa0a
Removing intermediate container c491fccba928
Step 5/8 : RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o zendesk-mock .
 ---> Running in 13282fbaddfa
 ---> 55f0549d959c
Removing intermediate container 13282fbaddfa
Step 6/8 : FROM scratch
 --->
Step 7/8 : COPY --from=golang-build /go/src/github.com/AirHelp/zendesk-mock/zendesk-mock .
 ---> 83733088e11f
Removing intermediate container f9ed2575271f
Step 8/8 : CMD /zendesk-mock
 ---> Running in 4c3d512f690c
 ---> 1188b14ed561
Removing intermediate container 4c3d512f690c
Successfully built 1188b14ed561
Successfully tagged zendesk-mock:test
```

size:
```
$ docker images zendesk-mock:test
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
zendesk-mock        test                1188b14ed561        15 seconds ago      7.74MB
```