### PR TITLE
fix unkeyed fields errors in mocks when running go vet

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -1,9 +1,10 @@
 package mocks
 
 import (
-	"github.com/AirHelp/zendesk-mock/api"
 	"math/rand"
 	"time"
+
+	"github.com/AirHelp/zendesk-mock/api"
 )
 
 func Id() int {
@@ -41,24 +42,78 @@ func Group(id int, name string) api.GroupEnvelope {
 
 func Ticket(id int, subject string) api.TicketEnvelope {
 	customs := []api.CustomField{
-		api.CustomField{28367069, "GF4534"},                                                //reference
-		api.CustomField{28518725, "delayed"},                                               //type
-		api.CustomField{28367089, "600"},                                                   //comp_per_pass
-		api.CustomField{28518845, "600.0"},                                                 //comp_per_pass_decimal
-		api.CustomField{28518825, "600"},                                                   //comp_total
-		api.CustomField{28367689, "600.0"},                                                 //compt_total_decimal
-		api.CustomField{28367989, "en"},                                                    //locale
-		api.CustomField{28368009, "ch_web"},                                                //channel
-		api.CustomField{28518885, "John Doe"},                                              //pass1
-		api.CustomField{28518905, "John F. Kennedy International Airport, New York (JFK)"}, //departure
-		api.CustomField{28368029, "Tegel Airport, Berlin (TXL)"},                           //arrival
-		api.CustomField{28518945, "LOT - Polish Airlines (LO)"},                            //airline_name_and_code
-		api.CustomField{28368069, "554"},                                                   //flight_no
-		api.CustomField{28368089, "2017-03-13"},                                            //date
-		api.CustomField{28518965, "LO"},                                                    //airline_code
-		api.CustomField{29960329, ""},                                                      //linked_ticket
+		api.CustomField{
+			ID:    28367069,
+			Value: "GF4534",
+		}, //reference
+		api.CustomField{
+			ID:    28518725,
+			Value: "delayed",
+		}, //type
+		api.CustomField{
+			ID:    28367089,
+			Value: "600",
+		}, //comp_per_pass
+		api.CustomField{
+			ID:    28518845,
+			Value: "600.0",
+		}, //comp_per_pass_decimal
+		api.CustomField{
+			ID:    28518825,
+			Value: "600",
+		}, //comp_total
+		api.CustomField{
+			ID:    28367689,
+			Value: "600.0",
+		}, //compt_total_decimal
+		api.CustomField{
+			ID:    28367989,
+			Value: "en",
+		}, //locale
+		api.CustomField{
+			ID:    28368009,
+			Value: "ch_web",
+		}, //channel
+		api.CustomField{
+			ID:    28518885,
+			Value: "John Doe",
+		}, //pass1
+		api.CustomField{
+			ID:    28518905,
+			Value: "John F. Kennedy International Airport, New York (JFK)",
+		}, //departure
+		api.CustomField{
+			ID:    28368029,
+			Value: "Tegel Airport, Berlin (TXL)",
+		}, //arrival
+		api.CustomField{
+			ID:    28518945,
+			Value: "LOT - Polish Airlines (LO)",
+		}, //airline_name_and_code
+		api.CustomField{
+			ID:    28368069,
+			Value: "554",
+		}, //flight_no
+		api.CustomField{
+			ID:    28368089,
+			Value: "2017-03-13",
+		}, //date
+		api.CustomField{
+			ID:    28518965,
+			Value: "LO",
+		}, //airline_code
+		api.CustomField{
+			ID:    29960329,
+			Value: "",
+		}, //linked_ticket
 	}
-	return api.TicketEnvelope{api.Ticket{id, subject, customs}}
+	return api.TicketEnvelope{
+		Ticket: api.Ticket{
+			ID:           id,
+			Subject:      subject,
+			CustomFields: customs,
+		},
+	}
 }
 
 func User(id int, name string) api.UserEnvelope {


### PR DESCRIPTION
When I ran make test using go 1.9 I got a whole lot of composite literal uses unkeyed fields errors. I've simply fixed them to allow the tests to complete.